### PR TITLE
Using -dump_coverage=1 instead of "ASAN_OPTIONS=coverage=1"

### DIFF
--- a/lessons/08/README.md
+++ b/lessons/08/README.md
@@ -162,7 +162,7 @@ strings corpus2_min/* | more
 ### Generate coverage report
 
 ```bash
-ASAN_OPTIONS=coverage=1 ./xml_read_memory_fuzzer corpus1_min -runs=0
+./xml_read_memory_fuzzer corpus1_min -runs=0 -dump_coverage=1
 ```
 
 This command should generate `.sancov` file in your working directory:


### PR DESCRIPTION
I don't know why but "ASAN_OPTIONS=coverage=1" isn't working in my test. But -dump_coverage=1 works :)